### PR TITLE
Use the generic ci-helpers script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
 script:
    - $MAIN_CMD $SETUP_CMD


### PR DESCRIPTION
Using the generic script will allow us to put more generic stuff in there without code repetition, e.g. the checks for the custom tags and skipping the builds early.