### PR TITLE
Fix SecurityMethod parsing of capabilities.

### DIFF
--- a/pyvo/dal/tests/data/tap/capabilities.xml
+++ b/pyvo/dal/tests/data/tap/capabilities.xml
@@ -14,6 +14,7 @@
   <capability standardID="ivo://ivoa.net/std/VOSI#tables">
     <interface role="std" xsi:type="vs:ParamHTTP">
       <accessURL use="full">http://dc.zah.uni-heidelberg.de/__system__/tap/run/tableMetadata</accessURL>
+      <securityMethod standardID="http://www.w3.org/Protocols/HTTP/1.0/spec.html#BasicAA"/>
     </interface>
   </capability>
   <capability standardID="ivo://ivoa.net/std/TAP" xsi:type="tr:TableAccess">

--- a/pyvo/io/vosi/voresource.py
+++ b/pyvo/io/vosi/voresource.py
@@ -151,6 +151,40 @@ class AccessURL(ContentMixin, Element):
         self._use = use
 
 
+class SecurityMethod(ContentMixin, Element):
+    """
+    SecurityMethod element as described in
+    http://www.ivoa.net/xml/VOResource/v1.0
+
+    A description of a security mechanism.
+
+    this type only allows one to refer to the mechanism via a URI.
+    Derived types would allow for more metadata.
+    """
+    def __init__(
+        self, config=None, pos=None, _name='securityMethod', standardID=None,
+        **kwargs
+    ):
+        super(SecurityMethod, self).__init__(config, pos, _name, **kwargs)
+
+        self._standardid = standardID
+
+    def __repr__(self):
+        return '<SecurityMethod standardID={}>{}</SecurityMethod>'.format(
+            self.standardid, self.content)
+
+    @xmlattribute(name='standardID')
+    def standardid(self):
+        """
+        A URI identifier for a standard security mechanism.
+        """
+        return self._standardid
+
+    @standardid.setter
+    def standardid(self, standardid):
+        self._standardid = standardid
+
+
 class Interface(Element):
     """
     Interface element as described in
@@ -265,7 +299,7 @@ class Interface(Element):
         """
         return self._accessurls
 
-    @xmlelement(name='securityMethod')
+    @xmlelement(name='securityMethod', cls=SecurityMethod)
     def securitymethods(self):
         """
         the mechanism the client must employ to gain secure
@@ -409,40 +443,6 @@ class Capability(Element):
         The use of an IVOA identifier here implies that a
         VOResource description of the standard is registered and
         accessible.
-        """
-        return self._standardid
-
-    @standardid.setter
-    def standardid(self, standardid):
-        self._standardid = standardid
-
-
-class SecurityMethod(ContentMixin, Element):
-    """
-    SecurityMethod element as described in
-    http://www.ivoa.net/xml/VOResource/v1.0
-
-    A description of a security mechanism.
-
-    this type only allows one to refer to the mechanism via a URI.
-    Derived types would allow for more metadata.
-    """
-    def __init__(
-        self, config=None, pos=None, _name='securityMethod', standardID=None,
-        **kwargs
-    ):
-        super(SecurityMethod, self).__init__(config, pos, _name, **kwargs)
-
-        self._standardid = standardID
-
-    def __repr__(self):
-        return '<SecurityMethod standardID={}>{}</SecurityMethod>'.format(
-            self.standardid, self.content)
-
-    @xmlattribute(name='standardID')
-    def standardid(self):
-        """
-        A URI identifier for a standard security mechanism.
         """
         return self._standardid
 


### PR DESCRIPTION
There was a problem where if any SecurityMethod was mentioned,
there would be a parse error since the SecurityMethod class wasn't
being used.  Reorder the classes and add the correct attribute.