### PR TITLE
Fix pycodestyle errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@
 # Note that not all possible configuration values are present in this file.
 #
 # All configuration values have a default. Some values are defined in
-# the global Astropy configuration which is loaded here before anything else. 
+# the global Astropy configuration which is loaded here before anything else.
 # See astropy.sphinx.conf for which values are set there.
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -58,9 +58,9 @@ setup_cfg = dict(conf.items('metadata'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
 # needs_sphinx = '1.2'
-# astropy_helpers sets 1.2 as the required default; forcing 1.1 seems to 
+# astropy_helpers sets 1.2 as the required default; forcing 1.1 seems to
 # work fine, but this may need to change
-needs_sphinx = '1.1'    
+needs_sphinx = '1.1'
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
@@ -168,4 +168,3 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
-

--- a/examples/serialquery.py
+++ b/examples/serialquery.py
@@ -14,7 +14,7 @@
 # interface.
 #
 # This file has been put in the public domain by the authors,
-# Markus Demleitner <msdemlei@ari.uni-heidelberg.de> and 
+# Markus Demleitner <msdemlei@ari.uni-heidelberg.de> and
 # Stefan Becker <sbecker@ari.uni-heidelberg.de>.
 
 import contextlib
@@ -31,67 +31,66 @@ from pyvo.registry import regtap
 
 @contextlib.contextmanager
 def samp_accessible(astropy_table):
-	"""a context manager making astroy_table available under a (file)
-	URL for the controlled section.
+    """a context manager making astroy_table available under a (file)
+    URL for the controlled section.
 
-	This is useful with uploads.
-	"""
-	handle, f_name = tempfile.mkstemp(suffix=".xml")
-	with os.fdopen(handle, "w") as f:
-		astropy_table.write(output=f,
-			format="votable")
-	try:
-		yield "file://"+f_name
-	finally:
-		os.unlink(f_name)
+    This is useful with uploads.
+    """
+    handle, f_name = tempfile.mkstemp(suffix=".xml")
+    with os.fdopen(handle, "w") as f:
+        astropy_table.write(output=f,
+            format="votable")
+    try:
+        yield "file://"+f_name
+    finally:
+        os.unlink(f_name)
 
 
 @contextlib.contextmanager
 def SAMP_conn():
-	"""a context manager to give the controlled block a SAMP connection.
+    """a context manager to give the controlled block a SAMP connection.
 
-	The program will disconnect as the controlled block is exited.
-	"""
-	client = SAMPIntegratedClient(name="serialquery", 
-		description="A serial SCS querier.")
-	client.connect()
-	try:
-		yield client
-	finally:
-		client.disconnect()
+    The program will disconnect as the controlled block is exited.
+    """
+    client = SAMPIntegratedClient(name="serialquery",
+        description="A serial SCS querier.")
+    client.connect()
+    try:
+        yield client
+    finally:
+        client.disconnect()
 
 
 def broadcast(astropy_table):
-	"""broadcasts an astropy table object to all SAMP clients on the local
-	bus.
-	"""
-	with SAMP_conn() as client:
-		with samp_accessible(astropy_table) as table_url:
-			client.notify_all(
-				{
-					"samp.mtype": "table.load.votable",
-					"samp.params": {
-						"url": table_url,
-					}})
-			time.sleep(2)  # hack: give other clients time to pick our table up
+    """broadcasts an astropy table object to all SAMP clients on the local
+    bus.
+    """
+    with SAMP_conn() as client:
+        with samp_accessible(astropy_table) as table_url:
+            client.notify_all(
+                {
+                    "samp.mtype": "table.load.votable",
+                    "samp.params": {
+                        "url": table_url,
+                    }})
+            time.sleep(2)  # hack: give other clients time to pick our table up
 
 
 def main(query_terms, ra, dec, sr):
-	for resource in regtap.search(
-		keywords=[query_terms], servicetype="image"
-	):
-		print(resource.res_title)
-		result = resource.service.search((ra, dec), sr)
-		print(len(result))
-		if result:
-			break
-	else:
-		sys.exit("No service has results for CIRCLE({0}, {1}, {2})".format(
-			ra, dec, sr))
-	broadcast(result.table)
+    for resource in regtap.search(
+        keywords=[query_terms], servicetype="image"
+    ):
+        print(resource.res_title)
+        result = resource.service.search((ra, dec), sr)
+        print(len(result))
+        if result:
+            break
+    else:
+        sys.exit("No service has results for CIRCLE({0}, {1}, {2})".format(
+            ra, dec, sr))
+    broadcast(result.table)
 
 
 if __name__=="__main__":
-	# serialquery.py RA DEC SR
-	main("standard stars", *[float(v) for v in sys.argv[1:]])
-
+    # serialquery.py RA DEC SR
+    main("standard stars", *[float(v) for v in sys.argv[1:]])

--- a/pyvo/__init__.py
+++ b/pyvo/__init__.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-PyVO is a package providing access to remote data and services of the 
-Virtual observatory (VO) using Python.  
+PyVO is a package providing access to remote data and services of the
+Virtual observatory (VO) using Python.
 
 The pyvo module currently provides these main capabilities:
 
-* find archives that provide particular data of a particular type and/or 
+* find archives that provide particular data of a particular type and/or
   relates to a particular topic
 
   *  regsearch()

--- a/pyvo/dal/dbapi2.py
+++ b/pyvo/dal/dbapi2.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 An implementation of the Database API v2.0 interface to DAL VOTable responses.
-This only supports read-only access.  
+This only supports read-only access.
 """
 from __future__ import print_function, division
 
@@ -29,7 +29,7 @@ class Warning(StandardError):
     pass
 class InterfaceError(Error):
     """
-    DB-API exception indicating an error related to the database interface 
+    DB-API exception indicating an error related to the database interface
     rather than the database itself.
     """
     pass
@@ -46,7 +46,7 @@ class DataError(DatabaseError):
     pass
 class OperationalError(DatabaseError):
     """
-    DB-API exception indicating an error related to the database's operation 
+    DB-API exception indicating an error related to the database's operation
     and not necessarily under the control of the programmer.
     """
     pass
@@ -57,7 +57,7 @@ class IntegrityError(DatabaseError):
     pass
 class InternalError(DatabaseError):
     """
-    DB-API exception indicating an internal error that might indicate that 
+    DB-API exception indicating an internal error that might indicate that
     a connection or cursor is no longer valid.
     """
     pass
@@ -81,7 +81,7 @@ class TypeObject(object):
     def id(self): return self._values[0]
 
     def __eq__(self, other):
-        if not isinstance(other, TypeObject): 
+        if not isinstance(other, TypeObject):
             return False
         if other.id in self._values:
             return True
@@ -101,14 +101,14 @@ def connect(source):
 
 class Cursor(Iter):
     """
-    A class used to walk through a query response table row by row, 
+    A class used to walk through a query response table row by row,
     accessing the contents of each record (row) of the table.  This class
     implements the Python Database API.
     """
 
     def __init__(self, results):
-        """Create a cursor instance.  The constructor is not typically called 
-        by directly applications; rather an instance is obtained from calling a 
+        """Create a cursor instance.  The constructor is not typically called
+        by directly applications; rather an instance is obtained from calling a
         DalQuery's execute().
         """
         super(Cursor, self).__init__(results)
@@ -127,7 +127,7 @@ class Cursor(Iter):
                 typ = NUMBER
             elif fld.datatype in "char unicodeChar unsignedByte".split():
                 typ = STRING
-                
+
             out.append( (name, typ) )
 
         return tuple(out)
@@ -135,10 +135,10 @@ class Cursor(Iter):
     @property
     def description(self):
         """
-        a read-only sequence of 2-item seqences.  Each seqence describes 
+        a read-only sequence of 2-item seqences.  Each seqence describes
         a column in the results, giving its name and type_code.
         """
-        return self._description 
+        return self._description
 
     @property
     def rowcount(self):
@@ -150,8 +150,8 @@ class Cursor(Iter):
     @property
     def arraysize(self):
         """
-        the number of rows that will be returned by returned by a call to 
-        fetchmany().  This defaults to 1, but can be changed.  
+        the number of rows that will be returned by returned by a call to
+        fetchmany().  This defaults to 1, but can be changed.
         """
         return self._arraysize
     @arraysize.setter
@@ -177,7 +177,7 @@ class Cursor(Iter):
         -------
         tuple :
             The response is a tuple wherein each element is the value of the
-            corresponding table field.  
+            corresponding table field.
         """
         try:
             rec = self.next()
@@ -187,7 +187,7 @@ class Cursor(Iter):
             return out
         except StopIteration:
             return None
-        
+
     def fetchmany(self, size=None):
         """Fetch the next block of rows from the query result.
 
@@ -232,9 +232,9 @@ class Cursor(Iter):
         value : str
             The number of rows to skip or the row number to position to.
         mode : str
-            Either "relative" for a relative skip (default), or "absolute" 
-            to position to a row by its absolute index within the result set 
-            (zero-indexed). 
+            Either "relative" for a relative skip (default), or "absolute"
+            to position to a row by its absolute index within the result set
+            (zero-indexed).
         """
         if mode == "absolute":
             if value > 0:
@@ -246,9 +246,8 @@ class Cursor(Iter):
 
     def close(self):
         """Close the cursor object and free all resources.  This implementation
-        does nothing.  It is provided for compliance with the Python Database 
-        API.  
+        does nothing.  It is provided for compliance with the Python Database
+        API.
         """
-        # this can remain implemented as "pass" 
+        # this can remain implemented as "pass"
         pass
-

--- a/pyvo/registry/__init__.py
+++ b/pyvo/registry/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-a package for interacting with registries.  
+a package for interacting with registries.
 
 The regtap module supports access to the IVOA Registries
 """

--- a/scripts/ex_casA_image_cat.py
+++ b/scripts/ex_casA_image_cat.py
@@ -3,7 +3,7 @@ import pyvo as vo
 
 # find archives with x-ray images
 archives = vo.regsearch(servicetype='image', waveband='xray')
-                        
+
 # position of my favorite source
 pos = vo.object2pos('Cas A')
 
@@ -14,14 +14,14 @@ with open('cas-a.csv', 'w') as csv:
     for arch in archives:
         print "searching %s..." % arch.shortname
         try:
-             matches = arch.search(pos=pos, size=0.25)
+            matches = arch.search(pos=pos, size=0.25)
         except vo.DALAccessError, ex:
-             print "Trouble accessing %s archive (%s)"\
-                   % (arch.shortname, str(ex))
-             continue
+            print "Trouble accessing %s archive (%s)"\
+                  % (arch.shortname, str(ex))
+            continue
         print "...found %d images" % matches.nrecs
         for image in matches:
-             print >> csv, ','.join(
-              (arch.shortname, arch.title, image.title,
-               str(image.ra), str(image.dec), image.format,
-               image.getdataurl()) )
+            print >> csv, ','.join(
+             (arch.shortname, arch.title, image.title,
+              str(image.ra), str(image.dec), image.format,
+              image.getdataurl()) )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ norecursedirs = build docs/_build
 [ah_bootstrap]
 auto_use = True
 
-[pep8]
+[pycodestyle]
 # E101 - mix of tabs and spaces
 # W191 - use of tabs
 # W291 - trailing whitespace

--- a/tests/testLicense.py
+++ b/tests/testLicense.py
@@ -20,7 +20,7 @@ class LicenseTestCase(unittest.TestCase):
         self.assertTrue(
             len(filter(lambda ln: ln.startswith(license_ref_line), lines)) > 0,
             "{0} does not have license reference line".format(filename))
-        self.assertTrue(lines[0].startswith(license_ref_line) or 
+        self.assertTrue(lines[0].startswith(license_ref_line) or
                         lines[1].startswith(license_ref_line),
     "license reference line is not 1st or 2nd line in {0}".format(license_ref_line))
 
@@ -29,7 +29,7 @@ class LicenseTestCase(unittest.TestCase):
                         "license/LICENSE.rst appears to be missing (what dir are you in?)")
 
 def list_py_files(arg, dirname, names):
-    return map(lambda f: (f[:-3], os.path.join(dirname,f)), 
+    return map(lambda f: (f[:-3], os.path.join(dirname,f)),
                filter(lambda n: n.endswith(".py"), names))
 
 for dirp, dirs, files in os.walk("pyvo"):


### PR DESCRIPTION
This should fix all the whitespace errors currently emitted by
pycodestyle for this repo.

Fix setup.cfg to say pycodestyle since pep8 is deprecated.